### PR TITLE
Update af.toast.js

### DIFF
--- a/src/af.toast.js
+++ b/src/af.toast.js
@@ -99,7 +99,7 @@
 
 
     $.afui.toast=function(opts){
-        $(document.body).toast(opts);
+        return $(document.body).toast(opts);
     };
 
     $.afui.registerDataDirective("[data-toast]",function(item){


### PR DESCRIPTION
Return the new created "Toast"-Object, so you can access it later.
This could be used to hide the message on an external event for example:

var toast_msg = $.afui.toast({
    message: 'Text...',
    position:'bc',
    autoClose:false,
    type:'success'
});

...
toast_msg.hide();
...
